### PR TITLE
[twilio-status] Twilio: Can set a webhook URL to track the message's delivery status

### DIFF
--- a/library/Xi/Sms/Gateway/TwilioGateway.php
+++ b/library/Xi/Sms/Gateway/TwilioGateway.php
@@ -32,36 +32,36 @@ class TwilioGateway extends BaseHttpRequestGateway
      */
     private $numberFrom;
 
-	/**
-	 * @var string|null
-	 */
-	private $messagingServiceSid;
+    /**
+     * @var string|null
+     */
+    private $messagingServiceSid;
 
-	/**
-	 * @var string|null
-	 */
-	private $statusCallback;
+    /**
+     * @var string|null
+     */
+    private $statusCallback;
 
     /**
      * TwilioGateway constructor.
      * @param string $accountSid Your Account SID from twilio.com/console
      * @param string $authToken Your Auth Token from twilio.com/console
      * @param string $numberFrom A Twilio phone number you purchased at twilio.com/console
-	 * @param string|null $messagingServiceSid Messaging service SID to use for sending
-	 * @param string|null $statusCallback The URL Twilio calls to send delivery status information
+     * @param string|null $messagingServiceSid Messaging service SID to use for sending
+     * @param string|null $statusCallback The URL Twilio calls to send delivery status information
      */
     public function __construct(
         $accountSid,
         $authToken,
         $numberFrom,
-		$messagingServiceSid = null,
+        $messagingServiceSid = null,
         $statusCallback = null
     ) {
         $this->accountSid = $accountSid;
         $this->authToken = $authToken;
         $this->numberFrom = $numberFrom;
-		$this->messagingServiceSid = $messagingServiceSid;
-		$this->statusCallback = $statusCallback;
+        $this->messagingServiceSid = $messagingServiceSid;
+        $this->statusCallback = $statusCallback;
     }
 
     /**
@@ -106,9 +106,9 @@ class TwilioGateway extends BaseHttpRequestGateway
         if ($this->messagingServiceSid) {
             $params['messagingServiceSid'] = $this->messagingServiceSid;
         }
-		if ($this->statusCallback) {
-			$params['statusCallback'] = $this->statusCallback;
-		}
+        if ($this->statusCallback) {
+            $params['statusCallback'] = $this->statusCallback;
+        }
 
         // Use the client to do fun stuff like send text messages!
         $MessageInstance = $client->messages->create(

--- a/library/Xi/Sms/Gateway/TwilioGateway.php
+++ b/library/Xi/Sms/Gateway/TwilioGateway.php
@@ -32,28 +32,36 @@ class TwilioGateway extends BaseHttpRequestGateway
      */
     private $numberFrom;
 
-    /**
-     * @var string|null
-     */
-    private $messagingServiceId;
+	/**
+	 * @var string|null
+	 */
+	private $messagingServiceSid;
+
+	/**
+	 * @var string|null
+	 */
+	private $statusCallback;
 
     /**
      * TwilioGateway constructor.
      * @param string $accountSid Your Account SID from twilio.com/console
      * @param string $authToken Your Auth Token from twilio.com/console
      * @param string $numberFrom A Twilio phone number you purchased at twilio.com/console
-     * @param string|null $messagingServiceId Messaging service SIDa
+	 * @param string|null $messagingServiceSid Messaging service SID to use for sending
+	 * @param string|null $statusCallback The URL Twilio calls to send delivery status information
      */
     public function __construct(
         $accountSid,
         $authToken,
         $numberFrom,
-        $messagingServiceId = null
+		$messagingServiceSid = null,
+        $statusCallback = null
     ) {
         $this->accountSid = $accountSid;
         $this->authToken = $authToken;
         $this->numberFrom = $numberFrom;
-        $this->messagingServiceId = $messagingServiceId;
+		$this->messagingServiceSid = $messagingServiceSid;
+		$this->statusCallback = $statusCallback;
     }
 
     /**
@@ -95,9 +103,12 @@ class TwilioGateway extends BaseHttpRequestGateway
             // the body of the text message you'd like to send
             'body' => $content,
         );
-        if ($this->messagingServiceId) {
-            $params['messagingServiceSid'] = $this->messagingServiceId;
+        if ($this->messagingServiceSid) {
+            $params['messagingServiceSid'] = $this->messagingServiceSid;
         }
+		if ($this->statusCallback) {
+			$params['statusCallback'] = $this->statusCallback;
+		}
 
         // Use the client to do fun stuff like send text messages!
         $MessageInstance = $client->messages->create(


### PR DESCRIPTION
Twilio: Can set a webhook URL to track the message's delivery status. See official documentation: 
https://www.twilio.com/docs/sms/api/message-resource?code-sample=code-create-a-message-and-specify-a-statuscallback-url&code-language=PHP&code-sdk-version=6.x