### PR TITLE
[twilio-fix-messaging-service] Fix use of Messaging Service

### DIFF
--- a/library/Xi/Sms/Gateway/TwilioGateway.php
+++ b/library/Xi/Sms/Gateway/TwilioGateway.php
@@ -99,12 +99,13 @@ class TwilioGateway extends BaseHttpRequestGateway
         }
 
         $params = array(
-            'from' => '+' . $this->numberFrom,
             // the body of the text message you'd like to send
             'body' => $content,
         );
         if ($this->messagingServiceSid) {
             $params['messagingServiceSid'] = $this->messagingServiceSid;
+        } else {
+            $params['from'] = '+' . $this->numberFrom;
         }
         if ($this->statusCallback) {
             $params['statusCallback'] = $this->statusCallback;


### PR DESCRIPTION
Fix using a Messaging Service to send SMS. See https://www.twilio.com/docs/messaging/services/tutorials/how-to-send-sms-messages-services-php#send-an-sms-message-with-a-messaging-service